### PR TITLE
API 31以上のデバイスでクラッシュする問題の対策

### DIFF
--- a/app/src/main/java/com/devrel/android/fitactions/tracking/FitTrackingService.kt
+++ b/app/src/main/java/com/devrel/android/fitactions/tracking/FitTrackingService.kt
@@ -54,7 +54,9 @@ class FitTrackingService : Service() {
      */
     private val notificationBuilder: NotificationCompat.Builder by lazy {
         val pendingIntent = Intent(this, FitMainActivity::class.java).let { notificationIntent ->
-            PendingIntent.getActivity(this, 0, notificationIntent, 0)
+            val flags =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+            PendingIntent.getActivity(this, 0, notificationIntent, flags)
         }
         NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getText(R.string.tracking_notification_title))


### PR DESCRIPTION
# Crash Log
```
     Caused by: java.lang.IllegalArgumentException: com.leoleo2.android.fitactions: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
        at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:458)
        at android.app.PendingIntent.getActivity(PendingIntent.java:444)
        at android.app.PendingIntent.getActivity(PendingIntent.java:408)
        at com.devrel.android.fitactions.tracking.FitTrackingService$notificationBuilder$2.invoke(FitTrackingService.kt:57)
        at com.devrel.android.fitactions.tracking.FitTrackingService$notificationBuilder$2.invoke(FitTrackingService.kt:55)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
        at com.devrel.android.fitactions.tracking.FitTrackingService.getNotificationBuilder(FitTrackingService.kt:55)
        at com.devrel.android.fitactions.tracking.FitTrackingService.onCreate(FitTrackingService.kt:84)
        at android.app.ActivityThread.handleCreateService(ActivityThread.java:4554)
        	... 9 more
```


# Behavior changes: Apps targeting Android 12:
https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability
https://developer.android.com/guide/components/intents-filters#DeclareMutabilityPendingIntent
